### PR TITLE
Add 1.18 Support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,12 +19,12 @@ org.gradle.jvmargs=-Xmx1G
 
 
 
-minecraft_version=1.17.1
-yarn_mappings=1.17.1+build.52
-loader_version=0.11.6
+minecraft_version=1.18.1
+yarn_mappings=1.18.1+build.11
+loader_version=0.12.12
 
 #Fabric api
-fabric_version=0.40.0+1.17
+fabric_version=0.45.0+1.18
 
 
 

--- a/src/main/java/yan/lx/bedrockminer/utils/InventoryManager.java
+++ b/src/main/java/yan/lx/bedrockminer/utils/InventoryManager.java
@@ -114,7 +114,8 @@ public class InventoryManager {
     public static int getInventoryItemCount(ItemConvertible item) {
         MinecraftClient minecraftClient = MinecraftClient.getInstance();
         PlayerInventory playerInventory = minecraftClient.player.getInventory();
-        return playerInventory.count((Item) item);
+        return 10; /*  Temporary fix as I do not know what the updated function is  */
+        // return playerInventory.count((Item) item);
     }
 
     public static String warningMessage() {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
 
   "depends": {
     "fabricloader": ">=0.11.3",
-    "minecraft": "1.16.x",
+    "minecraft": "1.18.x",
     "java": ">=8"
   },
   "suggests": {


### PR DESCRIPTION
Currently there is an issue with the `playerInventory.count((Item) item);` code so I implemented a temporary fix by just returning a fixed value, It seems that this function changed from 1.17 to 1.18 and Im not sure where to find the updated code.