### PR TITLE
Prevents mod from flooding game logs with messages

### DIFF
--- a/src/main/java/yan/lx/bedrockminer/utils/BreakingFlowController.java
+++ b/src/main/java/yan/lx/bedrockminer/utils/BreakingFlowController.java
@@ -42,8 +42,6 @@ public class BreakingFlowController {
             if (shouldAddNewTargetBlock(pos)){
                 TargetBlock targetBlock = new TargetBlock(pos, world);
                 cachedTargetBlockList.add(targetBlock);
-                //Suggest also an english version, for debug reasons.
-                System.out.println("新任务");
             }
         } else {
             //Does not Have an english version, Left out of lang for now. (raw To prevent Errors)

--- a/src/main/java/yan/lx/bedrockminer/utils/TargetBlock.java
+++ b/src/main/java/yan/lx/bedrockminer/utils/TargetBlock.java
@@ -48,7 +48,6 @@ public class TargetBlock {
     public Status tick() {
         this.tickTimes++;
         updateStatus();
-        System.out.println(this.status);
         switch (this.status) {
             case UNINITIALIZED:
                 InventoryManager.switchToItem(Blocks.PISTON);


### PR DESCRIPTION
Removes the `System.out.println` function in order to prevent games logs from being flooded with status changes.