### PR TITLE
Update to 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'fabric-loom' version '0.12-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -30,6 +30,10 @@ repositories {
 // 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 // 	// You may need to force-disable transitiveness on them.
 // }
+
+loom {
+	accessWidenerPath = file("src/main/resources/bedrock-miner.accesswidener")
+}
 
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,12 +14,12 @@ org.gradle.jvmargs=-Xmx1G
 
 # # Dependencies
 
-minecraft_version=1.18.2
-yarn_mappings=1.18.2+build.1
-loader_version=0.13.3
+minecraft_version=1.19
+yarn_mappings=1.19+build.2
+loader_version=0.14.7
 
 #Fabric api
-fabric_version=0.47.9+1.18.2
+fabric_version=0.56.0+1.19
 
 ## 代理
 #systemProp.http.proxyHost=127.0.0.1

--- a/src/main/java/yan/lx/bedrockminer/utils/BlockPlacer.java
+++ b/src/main/java/yan/lx/bedrockminer/utils/BlockPlacer.java
@@ -64,7 +64,8 @@ public class BlockPlacer {
         ClientPlayerEntity player = minecraftClient.player;
         ItemStack itemStack = player.getStackInHand(Hand.MAIN_HAND);
 
-        minecraftClient.getNetworkHandler().sendPacket(new PlayerInteractBlockC2SPacket(Hand.MAIN_HAND, hitResult));
+        minecraftClient.interactionManager.sendSequencedPacket(minecraftClient.world, sequence ->
+            new PlayerInteractBlockC2SPacket(Hand.MAIN_HAND, hitResult, sequence));
 
         if (!itemStack.isEmpty() && !player.getItemCooldownManager().isCoolingDown(itemStack.getItem())) {
             ItemUsageContext itemUsageContext = new ItemUsageContext(player, Hand.MAIN_HAND, hitResult);

--- a/src/main/java/yan/lx/bedrockminer/utils/Messager.java
+++ b/src/main/java/yan/lx/bedrockminer/utils/Messager.java
@@ -2,33 +2,28 @@ package yan.lx.bedrockminer.utils;
 
 
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.network.MessageType;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
-
-import java.util.UUID;
 
 public class Messager {
     public static void actionBar(String message){
         MinecraftClient minecraftClient = MinecraftClient.getInstance();
-        minecraftClient.inGameHud.setOverlayMessage(new TranslatableText(message),false);
+        minecraftClient.inGameHud.setOverlayMessage(Text.translatable(message),false);
     }
     public static void rawactionBar(String message){
         MinecraftClient minecraftClient = MinecraftClient.getInstance();
-        Text text = new LiteralText(message);
+        Text text = Text.literal(message);
         minecraftClient.inGameHud.setOverlayMessage(text,false);
     }
 
     public static void chat(String message){
         MinecraftClient minecraftClient = MinecraftClient.getInstance();
-        minecraftClient.inGameHud.getChatHud().addMessage(new TranslatableText(message));
+        minecraftClient.inGameHud.getChatHud().addMessage(Text.translatable(message));
     }
 
     public static void rawchat(String message){
         MinecraftClient minecraftClient = MinecraftClient.getInstance();
-        Text text = new LiteralText(message);
-        minecraftClient.inGameHud.addChatMessage(MessageType.SYSTEM,text, UUID.randomUUID());
+        Text text = Text.literal(message);
+        minecraftClient.inGameHud.getChatHud().addMessage(text);
     }
 }
 

--- a/src/main/resources/bedrock-miner.accesswidener
+++ b/src/main/resources/bedrock-miner.accesswidener
@@ -1,0 +1,2 @@
+accessWidener	v1	named
+accessible   method   net/minecraft/client/network/ClientPlayerInteractionManager   sendSequencedPacket   (Lnet/minecraft/client/world/ClientWorld;Lnet/minecraft/client/network/SequencedPacketCreator;)V

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,11 +26,12 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.11.3",
-    "minecraft": "1.18.x",
+    "fabricloader": ">=0.14.7",
+    "minecraft": "1.19.x",
     "java": ">=17"
   },
   "suggests": {
     "another-mod": "*"
-  }
+  },
+  "accessWidener" : "bedrock-miner.accesswidener"
 }


### PR DESCRIPTION
Initial port to 1.19. For some reason the piston does not disappear after breaking the bedrock - but the bedrock is broken correctly.